### PR TITLE
Add release pipeline.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+---
+## Manually trigger pipeline to create a release with .zip archives of Neovim configurations
+name: Manual Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python (for version parsing)
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Get latest tag
+        id: get_tag
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+          echo "Latest tag: $LATEST_TAG"
+          echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Bump patch version
+        id: bump_version
+        run: |
+          LATEST="${{ steps.get_tag.outputs.latest_tag }}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST#v}"
+          NEW_TAG="v$MAJOR.$MINOR.$((PATCH + 1))"
+          echo "New tag: $NEW_TAG"
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create zip files
+        id: zip_configs
+        run: |
+          mkdir -p release-assets
+          for dir in config/*/; do
+            name=$(basename "$dir")
+            zip -r "release-assets/${name}.zip" "$dir"
+          done
+          echo "Zipped all configs."
+
+      - name: Create Git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.bump_version.outputs.new_tag }}"
+          git push origin "${{ steps.bump_version.outputs.new_tag }}"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.bump_version.outputs.new_tag }}
+          name: Release ${{ steps.bump_version.outputs.new_tag }}
+          token: ${{ secrets.RELEASE_TOKEN }}
+          files: release-assets/*.zip


### PR DESCRIPTION
Should work off of existing tags. Bumps the patch version (v0.0.X).

Create new minor/major releases manually, start with a vX.X.0 tag and the pipeline will pick up versioning off the most recent tag.