### PR TITLE
fix(copy): Fix freezing on copy/paste.

### DIFF
--- a/config/nvim/lua/config/options/clipboard.lua
+++ b/config/nvim/lua/config/options/clipboard.lua
@@ -8,7 +8,29 @@ elseif vim.g.platform == "mac" then
   vim.keymap.set({'n', 'x'}, '<leader>c', '"+y', { desc = "Copy to clipboard (macOS)" })
 elseif vim.g.platform == "linux" then
   -- Linux-specific keybinding (uses "+y", requires xclip or wl-clipboard)
+  
+  vim.o.clipboard = "unnamedplus"
+
   vim.keymap.set({'n', 'x'}, '<leader>c', '"+y', { desc = "Copy to clipboard (Linux)" })
+
+  local function paste()
+    return {
+      vim.fn.split(vim.fn.getreg(""), "\n"),
+      vim.fn.getregtype(""),
+    }
+  end
+
+  vim.g.clipboard = {
+    name = "OSC 52",
+    copy = {
+      ["+"] = require("vim.ui.clipboard.osc52").copy("+"),
+      ["*"] = require("vim.ui.clipboard.osc52").copy("*"),
+    },
+    paste = {
+      ["+"] = paste,
+      ["*"] = paste,
+    },
+  }
 else
   -- Fallback/default
   vim.keymap.set({'n', 'x'}, '<leader>c', '"+y', { desc = "Copy to clipboard (default)" })


### PR DESCRIPTION
First encountered the issue on Fedora 42 in wezterm. Terminal would freeze with the following message:

"Waiting for OSC 52 response from the terminal. Press Ctrl-C to interrupt…"